### PR TITLE
fix: remove React removeChild/appendChild hack

### DIFF
--- a/packages/react/src/CircaInput.tsx
+++ b/packages/react/src/CircaInput.tsx
@@ -124,27 +124,15 @@ export const CircaInput = forwardRef<CircaInputHandle, CircaInputProps>(
       onInputRef.current = props.onInput;
     });
 
-    // Sync props to HTML attributes (only updates changed attributes)
+    // Sync props to HTML attributes (only updates changed attributes).
+    // On initial mount, connectedCallback fires before React sets attributes (using defaults).
+    // This layout effect then sets all attributes, triggering attributeChangedCallback
+    // which rebuilds config and re-renders with correct values — all before browser paint.
     useLayoutEffect(() => {
       const el = elRef.current;
       if (!el) return;
       syncAttributes(el, props);
     });
-
-    // On initial mount: re-trigger connectedCallback so it picks up React-set attributes.
-    // React sets attributes asynchronously after DOM insertion, so the first connectedCallback
-    // fires before attributes exist. This remove/re-insert forces a second connectedCallback
-    // with all attributes present. Cannot be removed until the web component is refactored
-    // to defer initialization (see issue #6).
-    useLayoutEffect(() => {
-      const el = elRef.current;
-      if (!el) return;
-      const parent = el.parentNode;
-      if (!parent) return;
-      const next = el.nextSibling;
-      parent.removeChild(el);
-      next ? parent.insertBefore(el, next) : parent.appendChild(el);
-    }, []);
 
     // Register event listeners (once only; callbacks reference latest via refs)
     useEffect(() => {

--- a/packages/web-component/src/__tests__/circa-input.test.ts
+++ b/packages/web-component/src/__tests__/circa-input.test.ts
@@ -1443,4 +1443,90 @@ describe("CircaInputElement", () => {
       expect(valuenow).toBe(40);
     });
   });
+
+  describe("default-* attribute late initialization (React compat)", () => {
+    it("default-margin-low/high are applied when set after connectedCallback", () => {
+      const el2 = document.createElement("circa-input");
+      el2.setAttribute("min", "0");
+      el2.setAttribute("max", "100");
+      document.body.appendChild(el2);
+
+      // Set default-* attributes after connectedCallback (simulates React useLayoutEffect)
+      el2.setAttribute("default-value", "50");
+      el2.setAttribute("default-margin-low", "5");
+      el2.setAttribute("default-margin-high", "10");
+
+      const circaEl = el2 as unknown as {
+        readonly circaValue: {
+          value: number | null;
+          marginLow: number | null;
+          marginHigh: number | null;
+        };
+      };
+      expect(circaEl.circaValue.value).toBe(50);
+      expect(circaEl.circaValue.marginLow).toBe(5);
+      expect(circaEl.circaValue.marginHigh).toBe(10);
+
+      el2.remove();
+    });
+
+    it("default-* attributes are ignored after user interaction", () => {
+      const el2 = document.createElement("circa-input");
+      el2.setAttribute("min", "0");
+      el2.setAttribute("max", "100");
+      el2.setAttribute("default-value", "50");
+      document.body.appendChild(el2);
+
+      // Use keyboard to change value (simulates user interaction)
+      const valueEl = el2.shadowRoot?.querySelector(
+        "[part='value']",
+      ) as HTMLElement;
+      valueEl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+
+      const circaEl = el2 as unknown as {
+        readonly circaValue: { value: number | null };
+      };
+      const valueAfterInteraction = circaEl.circaValue.value;
+      expect(valueAfterInteraction).not.toBe(50);
+
+      // Changing default-value should NOT re-initialize
+      el2.setAttribute("default-value", "70");
+      expect(circaEl.circaValue.value).toBe(valueAfterInteraction);
+
+      el2.remove();
+    });
+
+    it("default-* attributes re-apply after clear()", () => {
+      const el2 = document.createElement("circa-input");
+      el2.setAttribute("min", "0");
+      el2.setAttribute("max", "100");
+      el2.setAttribute("default-value", "50");
+      document.body.appendChild(el2);
+
+      // Simulate user interaction
+      const valueEl = el2.shadowRoot?.querySelector(
+        "[part='value']",
+      ) as HTMLElement;
+      valueEl.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" }),
+      );
+
+      const circaEl = el2 as unknown as {
+        readonly circaValue: { value: number | null };
+        clear(): void;
+      };
+
+      // Clear resets the value
+      circaEl.clear();
+      expect(circaEl.circaValue.value).toBeNull();
+
+      // After clear, default-value should be re-applicable
+      el2.setAttribute("default-value", "70");
+      expect(circaEl.circaValue.value).toBe(70);
+
+      el2.remove();
+    });
+  });
 });

--- a/packages/web-component/src/circa-input.ts
+++ b/packages/web-component/src/circa-input.ts
@@ -125,6 +125,10 @@ export class CircaInputElement extends HTMLElement {
   /** @internal Deferred attribute update while dragging (controlled mode) */
   private _pendingAttributeUpdate = false;
 
+  /** @internal True after a value-changing operation; prevents default-* attributes from overwriting user choices.
+   *  Reset on clear() and connectedCallback() to allow re-initialization from defaults. */
+  private _defaultsLocked = false;
+
   /** @internal Form integration */
   private _internals: ElementInternals | null = null;
 
@@ -161,6 +165,8 @@ export class CircaInputElement extends HTMLElement {
   }
 
   connectedCallback(): void {
+    // Reset defaults lock so default-* attributes can re-apply on reconnection
+    this._defaultsLocked = false;
     this._config = buildConfig((name) => this.getAttribute(name));
     validateConfig(this._config);
     this._circaValue = clampMargins(
@@ -269,13 +275,14 @@ export class CircaInputElement extends HTMLElement {
     }
 
     // Handle default-* attributes set after connectedCallback
-    // (e.g., React sets attributes after DOM insertion)
+    // (e.g., React sets attributes after DOM insertion via useLayoutEffect).
+    // Re-initialize from defaults unless the user has already interacted.
     if (
       (_name === ATTR.DEFAULT_VALUE ||
         _name === ATTR.DEFAULT_MARGIN_LOW ||
         _name === ATTR.DEFAULT_MARGIN_HIGH) &&
       !this._isControlled &&
-      this._circaValue.value === null
+      !this._defaultsLocked
     ) {
       this._circaValue = clampMargins(
         buildInitialValue(
@@ -324,6 +331,8 @@ export class CircaInputElement extends HTMLElement {
       this._circaValue = initial;
       this._render();
       this._emitChange();
+      // Allow default-* attributes to re-apply after clear
+      this._defaultsLocked = false;
     }
   }
 
@@ -1006,6 +1015,7 @@ export class CircaInputElement extends HTMLElement {
 
   /** @internal Fire change event (on operation complete) */
   private _emitChange(): void {
+    this._defaultsLocked = true;
     this.dispatchEvent(
       new CustomEvent("change", {
         detail: this.circaValue,


### PR DESCRIPTION
## Summary

- **#6**: React ラッパーの `removeChild/appendChild` ハックを削除
- Web component 側に `_defaultsLocked` フラグを追加し、`attributeChangedCallback` で `default-*` 属性の遅延設定を正しく処理
- ハックが引き起こしていた問題（フォーカス消失、MutationObserver 干渉、SSR hydration 警告）を解消
- `clear()` と `connectedCallback()` でフラグをリセットし、再初期化を許可

Closes #6

## Test plan

- [x] `pnpm type-check` — 全パッケージ通過
- [x] `pnpm test` — 全263テスト通過（新規3件含む）
  - default-* 属性の遅延初期化
  - ユーザー操作後の default-* 無視
  - clear() 後の再初期化
- [x] `pnpm lint` — 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)